### PR TITLE
Writes to cache asynchronously

### DIFF
--- a/lib/link_cache/cache.ex
+++ b/lib/link_cache/cache.ex
@@ -1,7 +1,8 @@
 defmodule LinkCache.Cache do
+  use GenServer
+
   def start_link(_opts \\ []) do
-    :ets.new(__MODULE__, [:named_table, :duplicate_bag, :public, read_concurrency: true])
-    {:ok, self()}
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
   end
 
   def fetch(slug, default_value_function) do
@@ -19,7 +20,12 @@ defmodule LinkCache.Cache do
   end
 
   defp set(slug, value) do
-    :ets.insert(__MODULE__, {slug, value})
+    :ok = GenServer.cast(__MODULE__, {:set, slug, value})
     value
+  end
+
+  def handle_cast({:set, slug, value}, state) do
+    true = :ets.insert(__MODULE__, {slug, value})
+    {:noreply, state}
   end
 end

--- a/lib/link_cache/supervisor.ex
+++ b/lib/link_cache/supervisor.ex
@@ -10,6 +10,12 @@ defmodule LinkCache.Supervisor do
       worker(LinkCache.Cache, [[name: LinkCache.Cache]])
     ]
 
+    create_cache_table
+
     supervise(children, strategy: :one_for_one)
+  end
+
+  def create_cache_table do
+    :ets.new(LinkCache.Cache, [:named_table, :duplicate_bag, :public, read_concurrency: true])
   end
 end

--- a/test/lib/link_cache/cache_test.exs
+++ b/test/lib/link_cache/cache_test.exs
@@ -6,6 +6,9 @@ defmodule LinkCacheTest do
       %{id: 1, long_url: "http://www.example.com"}
     end) == %{id: 1, long_url: "http://www.example.com"}
 
+    # Gah, sorry about this
+    Process.sleep 10
+
     assert LinkCache.Cache.fetch("A", fn -> "" end) == %{id: 1, long_url: "http://www.example.com"}
   end
 end


### PR DESCRIPTION
As outlined here https://gist.github.com/cloud8421/34bcc0d5be7c3f2d2626d17562ace4f2
- Writes are async, with pattern match to crash process in case they go wrong
- Table is owned by supervisor
- In case cache write fails, request still succeeds.
